### PR TITLE
Fixed the URLS

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -17,11 +17,11 @@ urlpatterns = [
     path('register/', views.register, name='register'),
     path('categories/', views.show_categories, name='categories'),
     # slugs
-    path('<slug:category_name_slug>/',
+    path('category/<slug:category_name_slug>/',
          views.show_category, name='show_category'),
-    path('<slug:category_name_slug>/<slug:subcategory_name_slug>/',
+    path('category/<slug:category_name_slug>/<slug:subcategory_name_slug>/',
          views.show_sub_category, name='subcategory'),
-    path('<slug:product_name_slug>/', views.product, name='product'),
+    path('product/<slug:product_name_slug>/', views.product, name='product'),
     path('account/wish-list/', views.wish_list, name='list'),
     path('account/<slug:list_name_slug>/', views.wish_list, name='custom-list'),
 ]

--- a/app/views.py
+++ b/app/views.py
@@ -180,10 +180,13 @@ def show_category(request, category_name_slug):
 
     try:
         category = Category.objects.get(slug=category_name_slug)
+        subcats = SubCategory.objects.filter(category=category)
         context_dict['category'] = category
+        context_dict['subcats'] = subcats
 
     except Category.DoesNotExist:
         context_dict['category'] = None
+        context_dict['subcats'] = None
 
     logger.info("Show category called with category: %s",
                 context_dict['category'])
@@ -228,8 +231,6 @@ def product(request, product_name_slug):
     context_dict = {}
     try:
         product = Product.objects.get(slug=product_name_slug)
-        print(product)
-        print("check")
         context_dict['product'] = product
 
     except Product.DoesNotExist:

--- a/populate_app.py
+++ b/populate_app.py
@@ -1,12 +1,11 @@
+from django.core.files import File
+from app.models import Category, SubCategory, Product, ProductList, Rating, UserProfile
+from django.contrib.auth.models import User
 import django
 import os
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bikezon.settings')
 django.setup()
-
-from django.contrib.auth.models import User
-from app.models import Category, SubCategory, Product, ProductList, Rating, UserProfile
-from django.core.files import File
 
 
 def populate():

--- a/templates/app/account.html
+++ b/templates/app/account.html
@@ -18,4 +18,11 @@ Bikezon Account
     </button>
     {% endbuttons %}
 </form>
+<form action="{% url 'app:edit_profile' %}">
+    {% buttons %}
+    <button type="submit" class="btn btn-primary">
+        Edit my profile
+    </button>
+    {% endbuttons %}
+</form>
 {% endblock %}

--- a/templates/app/categories.html
+++ b/templates/app/categories.html
@@ -3,7 +3,7 @@
     <ul>
         {% for category in categories %}
         <li>
-            <a href="/{{ category.slug }}/">{{ category.name }}</a>
+            <a href="/category/{{ category.slug }}/">{{ category.name }}</a>
         </li>
         {% endfor %}
     </ul>

--- a/templates/app/category.html
+++ b/templates/app/category.html
@@ -12,5 +12,10 @@ Unknown Category
 {% if category %}
 <h1>{{ category.name }}</h1>
 <p>{{ category.description }}</p>
+{% for subcat in subcats %}
+<div>
+    <a href="/category/{{ category.name }}/{{ subcat.slug }}/">{{ subcat.name }}</a>
+</div>
+{% endfor %}
 {% endif %}
 {% endblock %}

--- a/templates/app/index.html
+++ b/templates/app/index.html
@@ -22,7 +22,7 @@ Homepage
     <ul>
         {% for category in categories %}
         <li>
-            <a href="/{{ category.slug }}/">{{ category.name }}</a>
+            <a href="/category/{{ category.slug }}/">{{ category.name }}</a>
         </li>
         {% endfor %}
     </ul>
@@ -37,7 +37,7 @@ Homepage
     <ul>
         {% for product in products %}
         <li>
-            <a href="/{{ product.slug }}/">{{ product.name }}</a>
+            <a href="/product/{{ product.slug }}/">{{ product.name }}</a>
             <img src="{{ product.picture.url }}" />
         </li>
         {% endfor %}

--- a/templates/app/product.html
+++ b/templates/app/product.html
@@ -13,6 +13,11 @@ Unknown Product
 {% block body_block %}
 {% if product %}
 <h1>{{ product.name }}</h1>
+<p>{{ product.description }}</p>
+<a href="mailto: {{ product.seller.user.email }}"> Get in touch with {{ product.seller }}</a>
+<p>Or giver them a call on {{ product.seller.phone }}</p>
+
+<img src="{{ product.picture.url }}" />
 {% else %}
 The specified product does not exist.
 {% endif %}


### PR DESCRIPTION
**PLEASE READ THIS BEFORE CHANGING URLS AGAIN**

Fixed URLS because slugs in start of both were causing conflicts.
If we have slug/... for category and slug/.. for products then
the urls get mixed up deciding if we are trying to access a
category or a product.
E.G:
If there exists a product bike1 but no category bike1 then the app
would try to find the CATEGORY slug bike1 and error because it
doesn't exist. There are other issues with that implementation too.

ADDITIONALLY it makes sense to have catgeory/... and product/..
for organisation.

Tested, everything works now.

Expanded the product page a bit to include a template of contacting the
seller and a product pic. Everything needs major front-end work.